### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vincentwijaya/go-pkg
+module github.com/vincentwijaya/go-pkg/v1
 
 go 1.13
 


### PR DESCRIPTION
Update go.mod name to match current github main branch release to prevent `v0.0.0-TIMESTAMP-COMMIT_HASH`